### PR TITLE
Handle missing/broken base_model or refiner_model in settings.json

### DIFF
--- a/modules/default_pipeline.py
+++ b/modules/default_pipeline.py
@@ -51,15 +51,15 @@ def load_base_model(name):
             print("Model not supported. Fooocus only support SDXL model as the base model.")
             xl_base = None
 
+        if xl_base is not None:
+            xl_base_hash = name
+            xl_base_patched = xl_base
+            xl_base_patched_hash = ""
+            print(f"Base model loaded: {xl_base_hash}")
+
     except:
         print(f"Failed to load {name}, loading default model instead")
         load_base_model(modules.path.default_base_model_name)
-
-    if xl_base is not None:
-        xl_base_hash = name
-        xl_base_patched = xl_base
-        xl_base_patched_hash = ""
-        print(f"Base model loaded: {xl_base_hash}")
 
     return
 

--- a/webui.py
+++ b/webui.py
@@ -299,14 +299,18 @@ with shared.gradio_root as block:
                     base_model = gr.Dropdown(
                         label="SDXL Base Model",
                         choices=modules.path.model_filenames,
-                        value=settings["base_model"],
+                        value=settings["base_model"]
+                            if settings["base_model"] in modules.path.model_filenames
+                            else modules.path.model_filenames[0],
                         show_label=True,
                     )
                     add_ctrl("base_model_name", base_model)
                     refiner_model = gr.Dropdown(
                         label="SDXL Refiner",
                         choices=["None"] + modules.path.model_filenames,
-                        value=settings["refiner_model"],
+                        value=settings["refiner_model"]
+                            if settings["refiner_model"] in modules.path.model_filenames
+                            else None,
                         show_label=True,
                     )
                     add_ctrl("refiner_model_name", refiner_model)


### PR DESCRIPTION
Fallback to the first model that is found if base_model path in settings doesn't match any model.
refiner_model fallback to None
And a small fix to not print output if model loading failed.