### PR TITLE
Fix: Specify UTF-8 encoding for file reading

### DIFF
--- a/modules/llama_pipeline.py
+++ b/modules/llama_pipeline.py
@@ -14,7 +14,7 @@ def llama_names():
         folder_path = Path("llamas")
         for path in folder_path.rglob("*"):
             if path.suffix.lower() in [".txt"]:
-                f = open(path, "r")
+                f = open(path, "r", encoding='utf-8')
                 name = f.readline().strip()
                 names.append((name, str(path)))
         names.sort(key=lambda x: x[0].casefold())
@@ -30,7 +30,7 @@ def run_llama(system_file, prompt):
             prompt = re.sub(sys_pat, "", prompt)
         else:
             try:
-                file = open(system_file, "r")
+                file = open(system_file, "r", encoding='utf-8')
                 name = name if name is not None else file.readline().strip()
                 system_prompt = file.read().strip()
             except:

--- a/ui_llama_chat.py
+++ b/ui_llama_chat.py
@@ -12,7 +12,7 @@ def create_chat():
         for path in folder_path.rglob("*"):
             if path.is_dir():
                 try:
-                    with open(path / "info.json" , "r") as f:
+                    with open(path / "info.json" , "r", encoding='utf-8') as f:
                         info = json.load(f)
                     names.append((info["name"], str(path)))
                 except Exception as e:
@@ -32,7 +32,7 @@ def create_chat():
     def _llama_select_assistant(dropdown):
         folder = Path(dropdown)
         try:
-            with open(folder / "info.json", "r") as f:
+            with open(folder / "info.json", "r", encoding='utf-8') as f:
                 info = json.load(f)
                 if "avatar" not in info:
                     info["avatar"] = folder / "avatar.png"


### PR DESCRIPTION
Fixes #246 by adding `encoding='utf-8'` to the `open()` function calls in the relevant files.

This PR addresses a `UnicodeDecodeError` that occurs when RuinedFooocus attempts to read configuration files (e.g., in the `llamas` and `chatbots` folders) containing multibyte characters such as Japanese.

The issue is likely due to the `open()` function defaulting to the system's default encoding (which is often CP932 on Japanese systems), rather than explicitly using UTF-8. This leads to a decoding error when encountering UTF-8 encoded files.

This PR adds `encoding='utf-8'` to the `open()` function calls in the following files:

- `modules/llama_pipeline.py` (in `llama_names` function)
- `modules/llama_pipeline.py` (in `run_llama` function)
- `modules/create_chat.py` (in `llama_get_assistants` function)

This ensures that files are read using UTF-8 encoding, properly supporting multibyte characters.