### PR TITLE
Fix #286: guard Canny thresholds against invalid values

### DIFF
--- a/modules/canny_utils.py
+++ b/modules/canny_utils.py
@@ -1,0 +1,45 @@
+import math
+from typing import Tuple
+
+
+def sanitize_canny_thresholds(low: float, high: float) -> Tuple[float, float]:
+    """
+    Normalize Canny thresholds to the valid range expected by kornia.
+
+    kornia.filters.canny requires 0 < low, high < 1 and low < high.
+    Users can currently set the sliders to 0.0 (or other invalid values),
+    which would cause a runtime error. This helper clamps values into a
+    safe range and enforces ordering while preserving the intent as much
+    as possible.
+    """
+    eps = 1e-6
+    max_val = 1.0 - eps
+
+    # Handle NaNs / infinities by falling back to reasonable defaults.
+    if not math.isfinite(low):
+        low = eps
+    if not math.isfinite(high):
+        high = max_val
+
+    # Clamp into the open interval (0, 1).
+    if low <= 0.0:
+        low = eps
+    if high <= 0.0:
+        high = max_val
+
+    low = max(eps, min(low, max_val))
+    high = max(eps, min(high, max_val))
+
+    # Ensure low < high. When they are equal or inverted, keep the
+    # lower bound as-is and nudge the upper bound upwards.
+    if not low < high:
+        # If low is already near the maximum, move it slightly down
+        # so that we still have a valid open interval.
+        if low >= max_val:
+            low = max_val - eps
+            high = max_val
+        else:
+            high = min(max_val, low + eps)
+
+    return float(low), float(high)
+

--- a/modules/sdxl_pipeline.py
+++ b/modules/sdxl_pipeline.py
@@ -81,6 +81,7 @@ from modules.pipeline_utils import (
     clean_prompt_cond_caches,
     set_timestep_range,
 )
+from modules.canny_utils import sanitize_canny_thresholds
 
 #from comfyui_gguf.nodes import gguf_sd_loader, DualCLIPLoaderGGUF, GGUFModelPatcher
 #from comfyui_gguf.ops import GGMLOps
@@ -636,10 +637,14 @@ class pipeline:
             self.refresh_controlnet(name=controlnet["type"])
             match controlnet["type"].lower():
                 case "canny":
+                    low, high = sanitize_canny_thresholds(
+                        float(controlnet.get("edge_low", 0.0)),
+                        float(controlnet.get("edge_high", 1.0)),
+                    )
                     input_image = Canny().detect_edge(
                         image=input_image,
-                        low_threshold=float(controlnet["edge_low"]),
-                        high_threshold=float(controlnet["edge_high"]),
+                        low_threshold=low,
+                        high_threshold=high,
                     )[0]
                     updated_conditions = True
                 case "depth":

--- a/tests/test_canny_thresholds.py
+++ b/tests/test_canny_thresholds.py
@@ -1,0 +1,36 @@
+import math
+import os
+import sys
+import unittest
+
+# Ensure project root is importable when running this file directly.
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from modules.canny_utils import sanitize_canny_thresholds
+
+
+class TestCannyThresholds(unittest.TestCase):
+    def test_zero_low_threshold_is_clamped_to_positive(self):
+        low, high = sanitize_canny_thresholds(0.0, 0.5)
+        self.assertGreater(low, 0.0)
+        self.assertLess(low, high)
+        self.assertLessEqual(high, 1.0)
+        self.assertTrue(math.isclose(high, 0.5))
+
+    def test_negative_thresholds_are_clamped_and_ordered(self):
+        low, high = sanitize_canny_thresholds(-1.0, 2.0)
+        self.assertGreater(low, 0.0)
+        self.assertLess(low, high)
+        self.assertLess(high, 1.0)
+
+    def test_high_less_than_low_is_corrected(self):
+        low, high = sanitize_canny_thresholds(0.5, 0.1)
+        self.assertGreater(low, 0.0)
+        self.assertLess(low, high)
+        self.assertLess(high, 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This pull request fixes runew0lf/RuinedFooocus#286 by hardening the Canny controlnet power-up path against invalid threshold values.

### What changed

- Added `modules.canny_utils.sanitize_canny_thresholds` to normalize user-provided Canny thresholds into the open interval `(0, 1)` expected by `kornia.filters.canny`.
  - Clamps negative and out-of-range values.
  - Handles `NaN` and infinities with safe defaults.
  - Ensures `low < high`, nudging the upper bound when necessary.
- Updated `modules.sdxl_pipeline.pipeline` to use `sanitize_canny_thresholds` before calling `Canny().detect_edge` in the `controlnet[type] == canny` branch.
- Added a small `unittest`-based test module `tests/test_canny_thresholds.py` to cover edge cases such as:
  - `low == 0.0` with a valid `high` (reproduces the original crash scenario).
  - Negative and greater-than-1.0 thresholds.
  - `high < low` cases.

### Why

Previously, when the Canny power-up sliders were set to values like `0.0` for the low threshold, the underlying `kornia.filters.canny` call would raise a runtime error because thresholds must satisfy `0 < low, high < 1` and `low < high`. This manifested as a crash when powering up with Canny controlnet enabled and certain slider positions.

By sanitizing thresholds in a central helper and using it in the SDXL pipeline, we prevent these crashes and avoid similar issues for other out-of-range inputs in the future.

### Testing

- Added and ran `python tests/test_canny_thresholds.py` to validate the behavior of `sanitize_canny_thresholds`.
- Verified that `modules/sdxl_pipeline.py` and `modules/canny_utils.py` pass `py_compile` (syntax check) without importing heavy runtime dependencies.