### PR TITLE
Allow textareas to be resized

### DIFF
--- a/modules/html.py
+++ b/modules/html.py
@@ -1,4 +1,7 @@
 css = """
+textarea {
+  resize: vertical;
+}
 .loader-container {
   display: flex; /* Use flex to align items horizontally */
   align-items: center; /* Center items vertically within the container */


### PR DESCRIPTION
This add a little thingy at the lower right corner of the main prompt input (and the negative one), allowing vertical resize of the textareas.

/!\ I have no idea if it's the right way to do things. Found it easiest to do it here, tested it, and it worked.  So please, be kind with this commit, and understand it's more a suggestion than a real pull request.