### PR TITLE
Update xllamacpp version & add ROCm 7.2.4 for Linux

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -138,8 +138,8 @@ def prepare_environment(offline=False):
             xlc_version = "xllamacpp==2026.7.9873"
             if REINSTALL_ALL or not is_installed(xlc_version):
                 platform_index = {
-                    'cu124': 'https://xorbitsai.github.io/xllamacpp/whl/cu124',
                     'cu128': 'https://xorbitsai.github.io/xllamacpp/whl/cu128',
+                    'cu132': 'https://xorbitsai.github.io/xllamacpp/whl/cu132',
                     'rocm6.4': 'https://xorbitsai.github.io/xllamacpp/whl/rocm-6.4.1',
                     'rocm7.2': 'https://xorbitsai.github.io/xllamacpp/whl/rocm-7.2.4',
                     'cpu': 'https://pypi.org/simple'

--- a/launch.py
+++ b/launch.py
@@ -135,13 +135,13 @@ def prepare_environment(offline=False):
             run_pip(f'install -r "{modules_file}"', "required modules")
 
         try:
-            xlc_version = "xllamacpp==0.2.7"
+            xlc_version = "xllamacpp==2026.7.9873"
             if REINSTALL_ALL or not is_installed(xlc_version):
                 platform_index = {
                     'cu124': 'https://xorbitsai.github.io/xllamacpp/whl/cu124',
                     'cu128': 'https://xorbitsai.github.io/xllamacpp/whl/cu128',
-                    'rocm6.3': 'https://xorbitsai.github.io/xllamacpp/whl/rocm-6.3.4',
                     'rocm6.4': 'https://xorbitsai.github.io/xllamacpp/whl/rocm-6.4.1',
+                    'rocm7.2': 'https://xorbitsai.github.io/xllamacpp/whl/rocm-7.2.4',
                     'cpu': 'https://pypi.org/simple'
                 }
                 if torch_platform not in platform_index:


### PR DESCRIPTION
ROCm 7.2.4 is now supported in xllamacpp for Linux: https://github.com/xorbitsai/xllamacpp/commit/c6889cd0b431a0bc83aec717e1d01489642b6a44 https://github.com/xorbitsai/xllamacpp/releases/tag/v2026.7.9873-rocm-7.2.4

Also removed support of ROCm 6.3.4 as it is no longer supported in original repo.

For Windows, moving from xllamacpp-0.2.7 to xllamacpp-2026.7.9873 is also important as with ROCm Python 3.12 packages xllamacpp crashing on 0.2.7 and works fine on 2026.7.9873